### PR TITLE
Remove "plugin" package dependency.

### DIFF
--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -5,10 +5,8 @@ package loader
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
-	"plugin"
 	"reflect"
 	"strings"
 
@@ -16,7 +14,6 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/internal/plugins/execplugin"
 	"sigs.k8s.io/kustomize/api/internal/plugins/fnplugin"
-	"sigs.k8s.io/kustomize/api/internal/plugins/utils"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -296,31 +293,7 @@ func (l *Loader) loadExecOrGoPlugin(resId resid.ResId) (resmap.Configurable, err
 var registry = make(map[string]resmap.Configurable)
 
 func (l *Loader) loadGoPlugin(id resid.ResId, absPath string) (resmap.Configurable, error) {
-	regId := relativePluginPath(id)
-	if c, ok := registry[regId]; ok {
-		return copyPlugin(c), nil
-	}
-	if !utils.FileExists(absPath) {
-		return nil, fmt.Errorf(
-			"expected file with Go object code at: %s", absPath)
-	}
-	log.Printf("Attempting plugin load from '%s'", absPath)
-	p, err := plugin.Open(absPath)
-	if err != nil {
-		return nil, errors.WrapPrefixf(err, "plugin %s fails to load", absPath)
-	}
-	symbol, err := p.Lookup(konfig.PluginSymbol)
-	if err != nil {
-		return nil, errors.WrapPrefixf(
-			err, "plugin %s doesn't have symbol %s",
-			regId, konfig.PluginSymbol)
-	}
-	c, ok := symbol.(resmap.Configurable)
-	if !ok {
-		return nil, fmt.Errorf("plugin '%s' not configurable", regId)
-	}
-	registry[regId] = c
-	return copyPlugin(c), nil
+	return nil, errors.Errorf("not implemented.")
 }
 
 func copyPlugin(c resmap.Configurable) resmap.Configurable {


### PR DESCRIPTION
This PR removes dependency on "plugin" package from kustomize, so we can decrease size of the "teleport" binary.
Related issue: https://github.com/kubernetes-sigs/kustomize/issues/5524